### PR TITLE
Deno compatibility with documented example

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,24 +10,14 @@ Diosaur is a small dependency injection solution written in Typescript for Deno 
 of code, avoiding obvious bindings and other repetitive stuff. It internally depends on `reflect-metadata` to guess
 the maximum indications out of your code, but still allows you for finer definition of your services.
 
-## Reflect Metadata
-As Diosaur relies on `reflect-metadata` and this library was not officially ported to Deno yet, you'll need
-to import it manually in your project.
-
 
 ## Example
 ```typescript
 /** Deno **/
-// Import reflect-metadata
-import 'https://raw.githubusercontent.com/rbuckton/reflect-metadata/master/Reflect.js';
-
 // Import diosaur
 import { Service, Parameter, Inject, setParameter, getContainer } from 'https://raw.githubusercontent.com/ovesco/diosaur/master/mod.ts';
 
 /** Node **/
-// Import reflect-metadata, first install it `npm install --save reflect-metadata`
-import 'reflect-metadata';
-
 // Import diosaur
 import { Service, Parameter, Inject } from 'diosaur';
 
@@ -58,11 +48,24 @@ getContainer().then((container) => {
 });
 ```
 
-## How does it work
 Generally speaking, a dependency injection library handles the lifecycle of your
 services, which means that you don't have to create or remove them, it's handled
 by the container. In Diosaur, services are Typescript `class` decorated with the
 `@Service` decorator as illustrated in the upper example.
+
+# Using it in Deno
+
+Currently use of decorator is not allowed by default in deno. 
+To run a module requiring diosaur you will need to provide a tsconfig.jsonconfig 
+file specifying `"experimentalDecorators": true`.
+
+For example to run the above example in deno:  
+```bash
+git clone https://github.com/ovesco/diosaur
+cd diosaur/demo
+deno run --config tsconfig.json deno_demo.ts
+```
+![image](https://user-images.githubusercontent.com/6702424/83362772-13bf1a80-a394-11ea-8bca-6312539641f8.png)
 
 ### Injecting services
 Another purpose of dependency injection is actually managing your dependencies for you.

--- a/demo/deno_demo.ts
+++ b/demo/deno_demo.ts
@@ -1,0 +1,27 @@
+import { Service, Parameter, Inject, setParameter, getContainer } from '../mod.ts';
+
+@Service()
+class Doggo {
+    constructor(@Parameter('doggoName') private name: string) {}
+
+    bark() {
+        return this.name.toUpperCase();
+    }
+}
+
+@Service()
+class JonSnow {
+
+    @Inject()
+    private doggo: Doggo;
+
+    yell() {
+        return `I'm Jon with my doggo ${this.doggo.bark()} !`;
+    }
+}
+
+setParameter('doggoName', 'Ghost');
+getContainer().then((container) => {
+    const jon = container.get(JonSnow);
+    console.log(jon.yell());
+});

--- a/demo/tsconfig.json
+++ b/demo/tsconfig.json
@@ -1,0 +1,12 @@
+{
+    "compilerOptions": {
+        "lib": ["dom", "ES2015"],
+        "esModuleInterop": true,
+        "experimentalDecorators": true,
+        "strictPropertyInitialization": false,
+        "emitDecoratorMetadata": true,
+        "strict": true,
+        "noUnusedLocals": true,
+        "noUnusedParameters": true
+    }
+}

--- a/deno_dist/index.ts
+++ b/deno_dist/index.ts
@@ -2,6 +2,7 @@ import { IContainer } from "./Container.ts";
 import Registrer from "./Metadata/Registrer.ts";
 import { Constructor, ServiceClassIdentifier, ServiceIdentifier } from "./Types.ts";
 import { FunctionFactory } from "./Factory.ts";
+import "https://raw.githubusercontent.com/rbuckton/reflect-metadata/master/Reflect.js";
 
 import {
     Service,

--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -1,5 +1,6 @@
 import { IContainer } from "./Container";
 import { Constructor, ServiceClassIdentifier, ServiceIdentifier } from "./Types";
+import "reflect-metadata";
 import { Service, Inject, InjectAll, Factory, Parameter } from './Decorators';
 export { Service, Inject, InjectAll, Factory, Parameter, IContainer, };
 export declare const getContainer: () => Promise<IContainer>;

--- a/dist/index.js
+++ b/dist/index.js
@@ -9,6 +9,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 };
 import Registrer from "./Metadata/Registrer";
 import { FunctionFactory } from "./Factory";
+import "reflect-metadata";
 import { Service, Inject, InjectAll, Factory, Parameter, } from './Decorators';
 export { Service, Inject, InjectAll, Factory, Parameter, };
 export const getContainer = () => __awaiter(void 0, void 0, void 0, function* () {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,8 @@
 {
-  "requires": true,
+  "name": "diosaur",
+  "version": "0.0.1",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "@types/comment-json": {
       "version": "1.1.1",
@@ -17,12 +19,14 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -49,7 +53,8 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -94,7 +99,8 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
     },
     "gitignore-parser": {
       "version": "0.0.2",
@@ -106,6 +112,7 @@
       "version": "7.1.6",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
       "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -125,6 +132,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -133,7 +141,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "minimal-polyfills": {
       "version": "2.1.2",
@@ -145,6 +154,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -159,6 +169,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -172,7 +183,8 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "reflect-metadata": {
       "version": "0.1.13",
@@ -185,14 +197,6 @@
       "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
       "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
       "dev": true
-    },
-    "rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "requires": {
-        "glob": "^7.1.3"
-      }
     },
     "run-exclusive": {
       "version": "2.2.7",
@@ -209,6 +213,12 @@
       "integrity": "sha512-EFzjnGAZ/w2jdX8zxV2annB2yyaW2cih1jCqim0N1PgVGc1+k+QhIuHGpDVnAIcGXUywBk+JON5GQDkKP8QHyQ==",
       "dev": true
     },
+    "typescript": {
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.3.tgz",
+      "integrity": "sha512-D/wqnB2xzNFIcoBG9FG8cXRDjiqSTbG2wd8DMZeQyJlP1vfTkIxH4GKveWaEBYySKIg+USu+E+EDIR47SqnaMQ==",
+      "dev": true
+    },
     "url-join": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
@@ -218,7 +228,8 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,17 +2,24 @@
   "devDependencies": {
     "@types/node": "^14.0.6",
     "denoify": "^0.2.18",
-    "reflect-metadata": "^0.1.13"
+    "reflect-metadata": "^0.1.13",
+    "typescript": "^3.9.3"
   },
   "name": "diosaur",
   "version": "0.0.1",
   "author": "guillaume hochet",
   "license": "MIT",
-  "keywords": ["inversion", "of", "control", "dependency", "injection", "typescript"],
+  "keywords": [
+    "inversion",
+    "of",
+    "control",
+    "dependency",
+    "injection",
+    "typescript"
+  ],
   "description": "A small dependency injection library in typescript",
   "scripts": {
-    "build": "tsc && npm run denoify",
-    "denoify": "npx denoify"
+    "build": "tsc && denoify"
   },
   "main": "dist/index.js",
   "denoPorts": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ import { IContainer } from "./Container";
 import Registrer from "./Metadata/Registrer";
 import { Constructor, ServiceClassIdentifier, ServiceIdentifier } from "./Types";
 import { FunctionFactory } from "./Factory";
+import "reflect-metadata";
 
 import {
     Service,


### PR DESCRIPTION
Hi,  
I think you underestimated Denoify, not only does it replace import but it also resolve dependencies. 

If in `src/index.ts` you import reflect-metadata:
![image](https://user-images.githubusercontent.com/6702424/83362919-71a03200-a395-11ea-8d2f-a7df7b308900.png)

You get in `deno_dist/index.ts`:  
![image](https://user-images.githubusercontent.com/6702424/83362946-ad3afc00-a395-11ea-8dc3-6ae0504c39d4.png)

It would even import the same correct version ( https://raw.githubusercontent.com/rbuckton/reflect-metadata/v0.1.13/Reflect.js as 0.1.13 is the version in package-lock.json ) but the maintainer of `reflect-metadata` forgot to create a github release of the last version so denoify have to fallback to master but it works. 

Denoify can do that thanks to this bit in package.json:

![image](https://user-images.githubusercontent.com/6702424/83363017-3baf7d80-a396-11ea-8c91-6a10caaa6541.png)

It works:  

![image](https://user-images.githubusercontent.com/6702424/83363032-61d51d80-a396-11ea-85be-9a1c3f08e606.png)

Unfortunately, you still have to use //@ts-ignore when using ``Reflect.getMetadata('design:paramtypes', target, key);`` or other `reflect-metadata` feature. There is currently no way of loading the types definitions in Deno.

It's working in node with: 

```typescript
///<reference path="../node_modules/reflect-metadata/Reflect.d.ts"/>
import "reflect-metadata";
```
In Deno this should theoretically work but it doesn't: 

```typescript
/// <deno-types path="https://raw.githubusercontent.com/rbuckton/reflect-metadata/master/Reflect.d.ts" />
import "https://raw.githubusercontent.com/rbuckton/reflect-metadata/master/Reflect.js";
```

However, this just impacts your developing experience a little bit, not the user experience of your user. 


